### PR TITLE
add check-air validation in Makefile for checking whether `air` package are installed or not 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 .PHONY: all
 
+check-air:
+ifeq (,$(wildcard ./bin/air))
+	curl -sSfL "https://raw.githubusercontent.com/cosmtrek/air/master/install.sh" | sh -s
+endif
+
 start:
 	@go run src/main.go
 
-dev:
+dev: check-air
 	./bin/air
 
 go-build:


### PR DESCRIPTION
add check-air validation in Makefile for checking whether `air` package are installed or not 